### PR TITLE
bugfix/remove-flash-from-money-transaction-form

### DIFF
--- a/app/controllers/money_transactions_controller.rb
+++ b/app/controllers/money_transactions_controller.rb
@@ -15,8 +15,6 @@ class MoneyTransactionsController < ApplicationController
     else
       @contract = result[:contract]
 
-      flash.now[:alert] = result[:exception_message]
-
       render 'money_transactions/new'
     end
   end

--- a/spec/controllers/money_transactions_controller_spec.rb
+++ b/spec/controllers/money_transactions_controller_spec.rb
@@ -72,10 +72,6 @@ describe MoneyTransactionsController, type: :controller do
       it 'assigns contract' do
         expect(assigns(:contract)).to be_a(DigiBank::MoneyTransaction::Contract::Create)
       end
-
-      it 'renders flash alert' do
-        expect(request.flash[:alert]).to eq(I18n.t('validation_errors.validation_failed'))
-      end
     end
   end
 end


### PR DESCRIPTION
1. Removed alert flash from the money transaction form page

Before:
<img width="1792" alt="Screenshot 2022-07-26 at 10 51 44" src="https://user-images.githubusercontent.com/38437488/180953161-bd766227-8669-4f06-bad5-7f86d8f41b82.png">

After:
<img width="1460" alt="Screenshot 2022-07-26 at 10 52 52" src="https://user-images.githubusercontent.com/38437488/180953323-f6d2deca-5026-4c32-a4e5-678ae58a37e4.png">

